### PR TITLE
Backports/jammy

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ xdg-desktop-portal-lxqt (0.2.0-0ubuntu1~ppa1) jammy; urgency=medium
   * Backport to Jammy.
   * Removed redundant "Repository-Browser" field from d/upstream/metadata.
   * Removed obsolete "-Wl,--as-needed" linker flag.
+  * Added "Rules-Requires-Root: no" to debian/control.
 
  -- Aaron Rainbolt <arraybolt3@gmail.com>  Tue, 05 Jul 2022 17:04:26 -0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 xdg-desktop-portal-lxqt (0.2.0-0ubuntu1~ppa1) jammy; urgency=medium
 
   * Backport to Jammy.
+  * Removed redundant "Repository-Browser" field from d/upstream/metadata.
 
  -- Aaron Rainbolt <arraybolt3@gmail.com>  Tue, 05 Jul 2022 17:04:26 -0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+xdg-desktop-portal-lxqt (0.2.0-0ubuntu1~ppa1) jammy; urgency=medium
+
+  * Backport to Jammy.
+
+ -- Aaron Rainbolt <arraybolt3@gmail.com>  Tue, 05 Jul 2022 17:04:26 -0500
+
 xdg-desktop-portal-lxqt (0.2.0-0ubuntu1) kinetic; urgency=medium
 
   * Initial release.

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,7 @@ xdg-desktop-portal-lxqt (0.2.0-0ubuntu1~ppa1) jammy; urgency=medium
 
   * Backport to Jammy.
   * Removed redundant "Repository-Browser" field from d/upstream/metadata.
+  * Removed obsolete "-Wl,--as-needed" linker flag.
 
  -- Aaron Rainbolt <arraybolt3@gmail.com>  Tue, 05 Jul 2022 17:04:26 -0500
 

--- a/debian/control
+++ b/debian/control
@@ -13,6 +13,7 @@ Standards-Version: 4.6.1
 Vcs-Browser: https://phab.lubuntu.me/source/liblxqt/
 Vcs-Git: https://phab.lubuntu.me/source/liblxqt.git
 Homepage: https://github.com/lxqt/qtxdg-tools
+Rules-Requires-Root: no
 
 Package: xdg-desktop-portal-lxqt
 Architecture: any

--- a/debian/rules
+++ b/debian/rules
@@ -2,7 +2,6 @@
 export DH_VERBOSE=1
 
 export LC_ALL=C.UTF-8
-export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
 
 %:

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -3,4 +3,3 @@ Bug-Database: https://github.com/lxqt/xdg-desktop-portal-lxqt/issues
 Bug-Submit: https://github.com/lxqt/xdg-desktop-portal-lxqt/issues/new
 Changelog: https://github.com/lxqt/xdg-desktop-portal-lxqt/blob/master/CHANGELOG
 Repository: https://github.com/lxqt/xdg-desktop-portal-lxqt
-Repository-Browser: https://github.com/lxqt/xdg-desktop-portal-lxqt


### PR DESCRIPTION
This one still gives me "W: xdg-desktop-portal-lxqt: wrong-name-for-upstream-changelog usr/share/doc/xdg-desktop-portal-lxqt/CHANGELOG", I think I'd have to change the source tarball to fix that, so I'm leaving it, but it is a warning, so just so you know, there it is. If it needs fixed, I'm happy to help fix it.